### PR TITLE
FEATURE | Add range slider for shades 

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "node-sass": "^4.14.1",
     "sass-loader": "^8.0.2",
     "vue": "^2.6.11",
-    "vue-color": "^2.7.1"
+    "vue-color": "^2.7.1",
+    "vue-slider-component": "^3.1.5"
   },
   "devDependencies": {
     "@tailwindcss/custom-forms": "^0.2.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="app">
+    <div id="app" :style="{ '--base-color': baseColor }">
         <div class="max-w-xl mx-auto">
             <h1 class="font-serif text-6xl font-black text-blue-800">
                 TailScale
@@ -25,6 +25,17 @@
                         <span class="text-sm uppercase">Color Value</span>
                         <color-picker v-model="baseColor" />
                     </label>
+                </div>
+
+                <div class="mt-4">
+                    <span class="text-sm uppercase">Brightness Spread</span>
+                    <slider
+                        v-model="spread"
+                        :min="-100"
+                        :max="100"
+                        :min-range="100"
+                        :tooltip-formatter="value => `${value}%`"
+                    />
                 </div>
             </div>
         </div>
@@ -88,6 +99,7 @@ green: {
 import Color from 'color';
 import ColorCard from './components/color-card';
 import ColorPicker from './components/color-picker';
+import Slider from 'vue-slider-component';
 
 export default {
     name: 'App',
@@ -106,32 +118,48 @@ export default {
             800: '#276749',
             900: '#22543d',
         },
+        spread: [ -90, 80 ],
     }),
 
     watch: {
-        baseColor(base) {
-            this.shades = this.generateColorScale(base);
-        },
+        baseColor: 'regenerateShades',
+        spread: 'regenerateShades',
     },
 
 
     methods: {
-        generateColorScale(base) {
-            const color = Color(base);
+        regenerateShades() {
+            const color = Color(this.baseColor);
             const white = Color('#ffffff');
             const black = Color('#000000');
 
-            return {
-                100: color.mix(white,0.9).hex(),
-                200: color.mix(white,0.7).hex(),
-                300: color.mix(white,0.5).hex(),
-                400: color.mix(white,0.3).hex(),
-                500: base,
-                600: color.mix(black,0.3).hex(),
-                700: color.mix(black,0.5).hex(),
-                800: color.mix(black,0.7).hex(),
-                900: color.mix(black,0.8).hex(),
+            const blackMultiplier = (this.spread[0] / 100) / 4;
+            const whiteMultiplier = (this.spread[1] / 100) / 4;
+            const multipliers = {
+                100: whiteMultiplier * 4,
+                200: whiteMultiplier * 3,
+                300: whiteMultiplier * 2,
+                400: whiteMultiplier * 1,
+                500: null,
+                600: blackMultiplier * 1,
+                700: blackMultiplier * 2,
+                800: blackMultiplier * 3,
+                900: blackMultiplier * 4,
             };
+
+            const shades = { };
+            for (const shade of Object.keys(multipliers)) {
+                const multiplier = multipliers[shade];
+                if (multiplier === null) {
+                    shades[shade] = this.baseColor;
+                } else if (multiplier > 0) {
+                    shades[shade] = color.mix(white, multiplier).hex();
+                } else {
+                    shades[shade] = color.mix(black, Math.abs(multiplier)).hex();
+                }
+            }
+
+            this.shades = shades;
         },
     },
 
@@ -139,6 +167,14 @@ export default {
     components: {
         ColorCard,
         ColorPicker,
+        Slider,
     },
 };
 </script>
+
+<style lang="scss">
+
+/* Slider styles */
+$themeColor: var(--base-color);
+@import '~vue-slider-component/lib/theme/default.scss';
+</style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8579,6 +8579,11 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
+vue-class-component@^7.1.0:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-7.2.3.tgz#a5b1abd53513a72ad51098752e2dedd499807cca"
+  integrity sha512-oEqYpXKaFN+TaXU+mRLEx8dX0ah85aAJEe61mpdoUrq0Bhe/6sWhyZX1JjMQLhVsHAkncyhedhmCdDVSasUtDw==
+
 vue-cli-plugin-tailwind@~1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/vue-cli-plugin-tailwind/-/vue-cli-plugin-tailwind-1.4.1.tgz#b1cfba53115c5e02b1e1f8a08b672d3aacd24093"
@@ -8624,6 +8629,21 @@ vue-loader@^15.9.2:
     loader-utils "^1.1.0"
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
+
+vue-property-decorator@^8.0.0:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/vue-property-decorator/-/vue-property-decorator-8.4.2.tgz#016e17f259f73bc547e77a50ce282ba18db4ee41"
+  integrity sha512-IqbARlvgPE2pzKfbecKxsu2yEH0Wv7hfHR6m4eZA3LTnNw9hveAX77vDfLFyTeMISS5N7Kucp/xRSHjcQ6bAfQ==
+  dependencies:
+    vue-class-component "^7.1.0"
+
+vue-slider-component@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/vue-slider-component/-/vue-slider-component-3.1.5.tgz#d9ad6f1a105c8a0a7b72f5b8f95656d07b8e4c36"
+  integrity sha512-RIDL2cjIfSMKxv7IeNQ5gn936SAaLi+UKc97xd8yN92zz0n5dK343GGSay/3ypzhR1C5YIN3n7/LclUQrIDoFg==
+  dependencies:
+    core-js "^3.6.5"
+    vue-property-decorator "^8.0.0"
 
 vue-style-loader@^4.1.0, vue-style-loader@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
This PR builds on top of #6 and adds an additional 'spread' slider to select the brightness spread of the generated colors.

It is a separate PR to discuss the specific range slider being used without influencing the generation logic itself.

![Screenshot_2020-06-06_13-22-04](https://user-images.githubusercontent.com/3374170/83943000-dd9cf300-a7f8-11ea-953c-34cfa60e0382.png)
